### PR TITLE
Scroll bug fix, Switch and Image Preview enhancements

### DIFF
--- a/frontend/src/components/MapContext.tsx
+++ b/frontend/src/components/MapContext.tsx
@@ -8,6 +8,7 @@ type MapContextType = {
   map: Map | null;
   bounds: any; // You can refine this later
   addPreviewLayer: (url: string) => void;
+  removePreviewLayer: () => void;
   addFireBoundary: (fireNumber: string) => void;
   updateMapView: (centre: [number,number], zoom: number) => void; //centre: [lon, lat]
   selectedFire: Fire | null;
@@ -20,6 +21,7 @@ export const MapContext = React.createContext<MapContextType>({
   map: null,
   bounds: null,
   addPreviewLayer: () => {},
+  removePreviewLayer: () => {},
   addFireBoundary: () => {},
   updateMapView: () => {},
   selectedFire: null,

--- a/frontend/src/components/StacSearchPanel.scss
+++ b/frontend/src/components/StacSearchPanel.scss
@@ -49,4 +49,18 @@
   position: fixed !important;
   top: 0;
   left: 0;
+
+}
+
+.analysis-spinner {
+  position: fixed;
+  top: '0';
+  left: '0';
+  right: '0';
+  bottom: '0';
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; // Make sure it's above other content
+  background-color: 'rgba(255, 255, 255, 0.7)';
 }

--- a/frontend/src/components/StacSearchPanel.scss
+++ b/frontend/src/components/StacSearchPanel.scss
@@ -1,0 +1,48 @@
+.image-search-options {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.5em;
+    margin-bottom: 2em;
+    margin-right: 2em;
+    margin-left: 2em;
+}
+
+.slider-box {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.slider-month-text {
+    margin-top: 0.5em;
+}
+
+.fire-emoji {
+    font-size: 2em;
+}
+
+.stac-interaction-box {
+    margin-top: 2em;
+    display: flex;
+    flex-direction: column;
+}
+
+.button-box {
+    display: flex;
+    gap: 0.5em;
+}
+
+.error-text {
+    color: red;
+}
+
+.image-interaction-box  {
+    margin-top: 0.5em;
+}
+
+.bcds-react-aria-Switch > span {
+  position: fixed !important;
+  top: 0;
+  left: 0;
+}

--- a/frontend/src/components/StacSearchPanel.scss
+++ b/frontend/src/components/StacSearchPanel.scss
@@ -41,6 +41,10 @@
     margin-top: 0.5em;
 }
 
+.image-interaction-box button{
+    margin-top: 0.5em;
+}
+
 .bcds-react-aria-Switch > span {
   position: fixed !important;
   top: 0;

--- a/frontend/src/components/StacSearchPanel.tsx
+++ b/frontend/src/components/StacSearchPanel.tsx
@@ -7,6 +7,7 @@ import { Accordion, AccordionGroup, Button, Switch } from '@bcgov/design-system-
 import Fire from './FireSelector';
 import { PuffLoader } from 'react-spinners';
 import { syncFireResults } from '../utils/apiService';
+import './StacSearchPanel.scss'
 
 interface StacSearchCriteria {
   collection: string | null;
@@ -269,10 +270,9 @@ const StacSearchPanel: React.FC = () => {
       <div className="panel-box">
         <h4>Image Search</h4>      
 
-        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '0.5em', 
-          marginBottom: '2em', marginRight: '2em', marginLeft: '2em' }}>
+        <div className="image-search-options">
           {/* Pre-fire slider */}
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <div className="slider-box">
             <h5>Pre-fire Offset</h5>
             <input
               type="range"
@@ -286,14 +286,14 @@ const StacSearchPanel: React.FC = () => {
                 }))
               }
             />
-            <div style={{ marginTop: '0.5em' }}>{searchCriteria.preOffset} month(s)</div>
+            <div className="slider-month-text">{searchCriteria.preOffset} month(s)</div>
           </div>
 
           {/* Fire emoji */}
-          <div style={{ fontSize: '2em' }}>🔥</div>
+          <div className="fire-emoji">🔥</div>
 
           {/* Post-fire slider */}
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <div className="slider-box">
             <h5>Post-fire Offset</h5>
             <input
               type="range"
@@ -307,7 +307,7 @@ const StacSearchPanel: React.FC = () => {
                 }))
               }
             />
-            <div style={{ marginTop: '0.5em' }}>{searchCriteria.postOffset} month(s)</div>
+            <div className="slider-month-text">{searchCriteria.postOffset} month(s)</div>
           </div>
         </div>
       </div>
@@ -323,20 +323,22 @@ const StacSearchPanel: React.FC = () => {
       />
       </label>
 
-      <div style={{marginTop:'2em'}}>
-        <Button onPress={handleSearch} isDisabled={loading}>
-          {loading ? 'Searching...' : 'Load images'}
-        </Button>
-        <Button style= {{marginLeft:'0.5em'}} onPress={handleStartAnalysis} isDisabled={!analysisReady || analysisRunning}>
-          Start Analysis
-        </Button>
+      <div className="stac-interaction-box">
+        <div className="button-box">
+          <Button onPress={handleSearch} isDisabled={loading}>
+            {loading ? 'Searching...' : 'Load images'}
+          </Button>
+          <Button onPress={handleStartAnalysis} isDisabled={!analysisReady || analysisRunning}>
+            Start Analysis
+          </Button>
+        </div>
         {/* Conditionally render the PuffLoader */}
         {analysisRunning && (
         <div className='analysis-spinner'>
           <PuffLoader color="#003366" size={150} />
         </div>
         )}
-        {error && <p style={{ color: 'red' }}>Error: {error}</p>}
+        {error && <p className="error-text">Error: {error}</p>}
         {searchResults.length > 0 && (
           <div>
             <AccordionGroup title='Pre ignition images' allowsMultipleExpanded>
@@ -345,16 +347,28 @@ const StacSearchPanel: React.FC = () => {
                   <div>
                     <strong>ID: </strong> {item.id} <br />
                     <strong>Cloud: </strong>{item.properties["eo:cloud_cover"].toFixed(0)}%<br />
-                    <div style={{marginTop: '0.5em'}}>
-                    <Switch style= {{marginTop: '0.5em',marginBottom: '0.5em'}} 
-                      children="Select as pre fire image"
-                      isSelected={selectedPreImageId === item.id}
-                      onChange={() => handlePreImageSelection(item.properties["eo:cloud_cover"].toFixed(0),
-                        new Date(item.properties.datetime).toLocaleDateString(), 
-                        item.id
-                      )}
-                    ></Switch>
-                    <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
+                    <div className="image-interaction-box">
+                      <Switch
+                        children="Select as pre fire image"
+                        isSelected={selectedPreImageId === item.id}
+                        onChange={(isSelected) => {
+                          if (isSelected) {
+                            handlePreImageSelection(
+                              Number(item.properties["eo:cloud_cover"].toFixed(0)),
+                              new Date(item.properties.datetime).toLocaleDateString(),
+                              item.id
+                            );
+                          } else {
+                            setSelectedPreImageId(null);
+                            setAnalysisConfig(prev => ({
+                              ...prev,
+                              preImageDate: null,
+                              preImageCloud: null,
+                            }));
+                          }
+                        }}
+                      />
+                      <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
                     </div>
                   </div>
                 </Accordion>
@@ -366,16 +380,28 @@ const StacSearchPanel: React.FC = () => {
                   <div>
                     <strong>ID: </strong> {item.id} <br />
                     <strong>Cloud: </strong>{item.properties["eo:cloud_cover"].toFixed(0)}%<br />
-                    <div style={{marginTop: '0.5em'}}>
-                    <Switch style= {{marginTop: '0.5em',marginBottom: '0.5em'}} 
-                      children="Select as post fire image"
-                      isSelected={selectedPostImageId === item.id}
-                      onChange={() => handlePostImageSelection(item.properties["eo:cloud_cover"].toFixed(0),
-                        new Date(item.properties.datetime).toLocaleDateString(),
-                        item.id
-                      )}
-                    ></Switch>
-                    <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
+                    <div className="image-interaction-box">
+                      <Switch
+                        children="Select as post fire image"
+                        isSelected={selectedPostImageId === item.id}
+                        onChange={(isSelected) => {
+                          if (isSelected) {
+                            handlePostImageSelection(
+                              Number(item.properties["eo:cloud_cover"].toFixed(0)),
+                              new Date(item.properties.datetime).toLocaleDateString(),
+                              item.id
+                            );
+                          } else {
+                            setSelectedPostImageId(null);
+                            setAnalysisConfig(prev => ({
+                              ...prev,
+                              postImageDate: null,
+                              postImageCloud: null,
+                            }));
+                          }
+                        }}
+                      />
+                      <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
                   </div>
                   </div>
                 </Accordion>

--- a/frontend/src/components/StacSearchPanel.tsx
+++ b/frontend/src/components/StacSearchPanel.tsx
@@ -29,7 +29,8 @@ interface AnalysisConfig {
 }
 
 const StacSearchPanel: React.FC = () => {
-  const { bounds, addPreviewLayer, selectedFire, setAnalysisFire } = useContext(MapContext);
+  const { bounds, addPreviewLayer, removePreviewLayer, selectedFire, setAnalysisFire } = useContext(MapContext);
+  const [previewLayerId, setPreviewLayerId] = useState<string | null>(null);
 
   const [searchCriteria, setSearchCriteria] = useState<StacSearchCriteria>({
     collection: 'sentinel-2-l2a',
@@ -368,7 +369,20 @@ const StacSearchPanel: React.FC = () => {
                           }
                         }}
                       />
-                      <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
+                      <Button
+                        size="small"
+                        onPress={() => {
+                          if (previewLayerId === item.id) {
+                            removePreviewLayer();
+                            setPreviewLayerId(null);
+                          } else {
+                            addPreviewLayer(item.assets.visual.href);
+                            setPreviewLayerId(item.id);
+                          }
+                        }}
+                      >
+                        {previewLayerId === item.id ? 'Remove preview' : 'Preview'}
+                      </Button>
                     </div>
                   </div>
                 </Accordion>
@@ -401,7 +415,20 @@ const StacSearchPanel: React.FC = () => {
                           }
                         }}
                       />
-                      <Button size='small' onPress={() => handlePreviewClick(item.assets.visual.href)}>Preview</Button>
+                    <Button
+                      size="small"
+                      onPress={() => {
+                        if (previewLayerId === item.id) {
+                          removePreviewLayer();
+                          setPreviewLayerId(null);
+                        } else {
+                          addPreviewLayer(item.assets.visual.href);
+                          setPreviewLayerId(item.id);
+                        }
+                      }}
+                    >
+                      {previewLayerId === item.id ? 'Remove preview' : 'Preview'}
+                    </Button>
                   </div>
                   </div>
                 </Accordion>

--- a/frontend/src/pages/severity-configuration.tsx
+++ b/frontend/src/pages/severity-configuration.tsx
@@ -55,6 +55,10 @@ const ConfigurationApp: React.FC = () => {
     setPreviewLayerUrl(url);
   };
 
+  const removePreviewLayer = () => {
+    setPreviewLayerUrl(null);
+  };
+
   const addFireBoundary = (fireNumber: string) => {
     const perimeterUrl = `https://openmaps.gov.bc.ca/geo/pub/ows?service=WFS&version=1.0.0&request=GetFeature&typeName=pub:WHSE_LAND_AND_NATURAL_RESOURCE.PROT_CURRENT_FIRE_POLYS_SP&outputFormat=application/json&srsName=EPSG:3857&CQL_FILTER=FIRE_NUMBER='${fireNumber}'`;
     setPerimeterLayerUrl(perimeterUrl);
@@ -226,7 +230,8 @@ const ConfigurationApp: React.FC = () => {
       map: mapInstance, 
       bounds, 
       addFireBoundary,
-      addPreviewLayer, 
+      addPreviewLayer,
+      removePreviewLayer,
       analysisFire,
       setAnalysisFire,
       updateMapView: handleUpdateMapView, 


### PR DESCRIPTION
1. Scroll bug due to BC Gov React Component "Switch" internal <span> element messing with positioning in the app (due to absolute position styling) - Resolved by forcing fixed position to this element.

2. StacSearchPanel inline styling put into new StacSearchPanel.scss stylesheet.

3. Fixed Switch element only being able to enter the "Toggled On" state, and unable to be "Toggled Off".

4. Added functionality to remove the map overlay image for the pre and post fire images previews.