### PR TITLE
Add select year viewer

### DIFF
--- a/backend/api/database.py
+++ b/backend/api/database.py
@@ -42,18 +42,34 @@ def check_connection():
         print(f"An unexpected error occurred: {e}")
         return False
 
-def get_unique_fire_numbers():
-    query = f"""
-        SELECT DISTINCT FIRE_NUMBER
-        FROM '{PARQUET_PATH}'
-        ORDER BY FIRE_NUMBER
-    """
-    return [row[0] for row in con.execute(query).fetchall()]
+def get_unique_fire_numbers(year:str=None):
+    if year:
+        query = f"""
+            SELECT DISTINCT FIRE_NUMBER
+            FROM '{PARQUET_PATH}' WHERE FIRE_YEAR=?
+            ORDER BY FIRE_NUMBER
+        """
+        return [row[0] for row in con.execute(query,[year]).fetchall()]
+    else:
+        query = f"""
+            SELECT DISTINCT FIRE_NUMBER
+            FROM '{PARQUET_PATH}'
+            ORDER BY FIRE_NUMBER
+        """
+        return [row[0] for row in con.execute(query).fetchall()]
 
-def get_fire_features(fire_number: str):
+def get_fire_features(year: str, fire_number: str):
     query = f"""
         SELECT ST_AsGeoJSON(geometry) AS geometry, *
         FROM '{PARQUET_PATH}'
-        WHERE FIRE_NUMBER = ?
+        WHERE FIRE_YEAR=? and FIRE_NUMBER = ?
     """
-    return con.execute(query, [fire_number]).fetchdf()
+    return con.execute(query, [year, fire_number]).fetchdf()
+
+def get_years_with_features():
+    query = f"""
+        SELECT DISTINCT FIRE_YEAR
+        FROM '{PARQUET_PATH}'
+        ORDER BY FIRE_YEAR
+    """
+    return [row[0] for row in con.execute(query).fetchall()]

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -42,7 +42,7 @@ async def lifespan(app: FastAPI):
                     await run_in_threadpool(append_geojson_to_geoparquet_s3, fire_key)
             elif geoparquet_on_s3() and len(fire_jsons)>0:
                 # update geoparque
-                fire_list = get_unique_fire_numbers()
+                fire_list = get_unique_fire_numbers(year=None)
                 for fire_json in fire_jsons:
                     year = fire_json.split('/')[-1].split('-')[0]
                     fire = fire_json.split('/')[-1].split('-')[1][:6]
@@ -76,22 +76,22 @@ app.add_middleware(
     allow_headers=["*"],
 )
         
-@app.get("/burn-severity", response_model=FireNumberList)
+@app.get("/burn-severity/{year}", response_model=FireNumberList)
 # def list_fire_numbers(token_payload: dict = Depends(verify_token)): #use this if you want to protect the route
-def list_fire_numbers(token_payload: dict = Depends(verify_token)):
+def list_fire_numbers(year: str, token_payload: dict = Depends(verify_token)):
     # protected route
     try:
-        fire_numbers = get_unique_fire_numbers()
+        fire_numbers = get_unique_fire_numbers(year=year)
         return {"fire_numbers": fire_numbers}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/burn-severity/{fire_number}", response_model=FeatureCollection)
-def get_fire_by_number(fire_number: str, token_payload: dict = Depends(verify_token)):
+@app.get("/burn-severity/{year}/{fire_number}", response_model=FeatureCollection)
+def get_fire_by_number(year: str, fire_number: str, token_payload: dict = Depends(verify_token)):
     # Protected route
-    # eg. N71148
+    # eg. 2025, N71148
     try:
-        df = get_fire_features(fire_number)
+        df = get_fire_features(year,fire_number)
         features = []
 
         for _, row in df.iterrows():
@@ -108,7 +108,7 @@ def get_fire_by_number(fire_number: str, token_payload: dict = Depends(verify_to
 async def sync_burn_severity(year:str, fire_number: str):
     try:
         logger.info(f'Syc BS for {year}-{fire_number}')
-        obj_list = s3_list_objects(file_prefix=f'2025-{fire_number}')
+        obj_list = s3_list_objects(file_prefix=f'{year}-{fire_number}')
         pattern = re.compile(r'.*/20\d{2}-[A-Z]\d{5}.*\.json$')
         fire_jsons = [doc for doc in obj_list if pattern.match(doc)]
         logger.info(str(fire_jsons))
@@ -129,18 +129,18 @@ async def sync_burn_severity(year:str, fire_number: str):
     return True
 
 
-@app.get(
-    "/docs/list/{fire_number}",
-    summary="get list of documents related to fire_number"
-)
-async def get_docs(fire_number:str, token_payload: dict = Depends(verify_token)):
-    # Protected route
-    pass
+# @app.get(
+#     "/docs/list/{year}/{fire_number}",
+#     summary="get list of documents related to fire_number"
+# )
+# async def get_docs(year:str,fire_number:str, token_payload: dict = Depends(verify_token)):
+#     # Protected route
+#     return HTTPException(status_code=404, detail="This route is not built")
 
 @app.get(
-    "/docs/download/{fire_number}"
+    "/docs/download/{year}/{fire_number}"
 )
-async def download_file(fire_number:str, token_payload: dict = Depends(verify_token)):
+async def download_file(year:str, fire_number:str, token_payload: dict = Depends(verify_token)):
     # Protected route
     """
     Returns a presigned URL for a file in S3-compliant storage.
@@ -148,8 +148,7 @@ async def download_file(fire_number:str, token_payload: dict = Depends(verify_to
     """
 
     # get list of s3 objects with the given prefix
-    # TODO: deal with year
-    obj_list = s3_list_objects(file_prefix=f'2025-{fire_number}')
+    obj_list = s3_list_objects(file_prefix=f'{year}-{fire_number}')
     if not obj_list:
         return HTTPException(status_code=404, detail="No files found for the given prefix.")
 

--- a/frontend/src/components/ol-maps/FireNumberSelector.tsx
+++ b/frontend/src/components/ol-maps/FireNumberSelector.tsx
@@ -1,0 +1,118 @@
+//src/components/ol-maps/FireNumberSelector.tsx
+import React, { useState, useMemo, useRef, useEffect } from 'react';
+import './Selectors.scss';
+
+interface FireNumberSelectorProps {
+  fires: string[];
+  selectedFire: string | null;
+  onFireSelect: (fire: string | null) => void;
+  disabled?: boolean;
+}
+
+const sortAlphaNumeric = (a: string, b: string): number => {
+  const r = /(\d+)|(\D+)/g;
+  const aParts = a.match(r) || [];
+  const bParts = b.match(r) || [];
+  const len = Math.min(aParts.length, bParts.length);
+
+  for (let i = 0; i < len; i++) {
+    const aNum = Number(aParts[i]);
+    const bNum = Number(bParts[i]);
+    if (!isNaN(aNum) && !isNaN(bNum)) {
+      if (aNum !== bNum) return aNum - bNum;
+    } else if (aParts[i] !== bParts[i]) {
+      return aParts[i].localeCompare(bParts[i]);
+    }
+  }
+  return aParts.length - bParts.length;
+};
+
+const FireNumberSelector: React.FC<FireNumberSelectorProps> = ({
+  fires,
+  selectedFire,
+  onFireSelect,
+  disabled = false
+}) => {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const sortedFires = useMemo(
+    () => [...fires].sort(sortAlphaNumeric),
+    [fires]
+  );
+
+  const filteredFires = useMemo(
+    () =>
+      sortedFires.filter(f =>
+        f.toLowerCase().includes(searchTerm.toLowerCase())
+      ),
+    [sortedFires, searchTerm]
+  );
+
+  useEffect(() => {
+    const onClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', onClickOutside);
+    return () => document.removeEventListener('mousedown', onClickOutside);
+  }, []);
+
+  const selectFire = (fire: string) => {
+    onFireSelect(fire);
+    setIsOpen(false);
+    setSearchTerm('');
+  };
+
+  return (
+    <div className="bcgov-fire-selector" ref={ref}>
+      <div className="bcgov-fire-selector-label">
+        <h4>Fire Number</h4>
+        <p>Select a fire to view burn severity</p>
+      </div>
+
+      <input
+        type="text"
+        className="bcgov-fire-selector-input"
+        placeholder={
+          disabled
+            ? 'Select a year first'
+            : selectedFire || 'Search fire number...'
+        }
+        value={searchTerm}
+        onChange={e => setSearchTerm(e.target.value)}
+        onClick={() => !disabled && setIsOpen(true)}
+        disabled={disabled}
+        aria-disabled={disabled}
+      />
+
+      {isOpen && !disabled && (
+        <div className="bcgov-fire-selector-dropdown">
+          {filteredFires.length === 0 ? (
+            <div className="bcgov-fire-selector-no-results">
+              No fires match “{searchTerm}”
+            </div>
+          ) : (
+            <ul className="bcgov-fire-selector-list">
+              {filteredFires.map(fire => (
+                <li
+                  key={fire}
+                  className={`bcgov-fire-selector-item ${
+                    fire === selectedFire ? 'selected' : ''
+                  }`}
+                  onClick={() => selectFire(fire)}
+                >
+                  {fire}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default FireNumberSelector;

--- a/frontend/src/components/ol-maps/FireSelector_db.tsx
+++ b/frontend/src/components/ol-maps/FireSelector_db.tsx
@@ -1,140 +1,37 @@
-import React, { useState, useEffect, useRef, useMemo } from 'react';
-import './Selectors.scss';
+import React from 'react';
+import FireYearSelector from './FireYearSelector';
+import FireNumberSelector from './FireNumberSelector';
 
-interface FireSelectorProps {
+interface FireSelectorDbProps {
   fires: string[];
-  onFireSelect: (fireNumber: string | null) => void;
+  selectedYear: string | null;
   selectedFire: string | null;
+  onYearSelect: (year: string | null) => void;
+  onFireSelect: (fire: string | null) => void;
 }
 
-const sortAlphaNumeric = (a: string, b: string): number => {
-  const regex = /(\d+)|(\D+)/g;
-  const aParts = String(a).match(regex) || [];
-  const bParts = String(b).match(regex) || [];
-  const len = Math.min(aParts.length, bParts.length);
-  for (let i = 0; i < len; i++) {
-    if (!isNaN(Number(aParts[i])) && !isNaN(Number(bParts[i]))) {
-      const diff = parseInt(aParts[i]) - parseInt(bParts[i]);
-      if (diff !== 0) return diff;
-    } else {
-      const diff = aParts[i].localeCompare(bParts[i]);
-      if (diff !== 0) return diff;
-    }
-  }
-  return aParts.length - bParts.length;
-};
-
-const FireSelector: React.FC<FireSelectorProps> = ({
+const FireSelectorDb: React.FC<FireSelectorDbProps> = ({
   fires,
-  onFireSelect,
-  selectedFire
+  selectedYear,
+  selectedFire,
+  onYearSelect,
+  onFireSelect
 }) => {
-  const [searchTerm, setSearchTerm] = useState('');
-  const [isOpen, setIsOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-
-  const sortedFires = useMemo(() => {
-    return [...fires].sort(sortAlphaNumeric);
-  }, [fires]);
-
-  const filteredFires = useMemo(() => {
-    return sortedFires.filter(fire =>
-      fire.toLowerCase().includes(searchTerm.toLowerCase())
-    );
-  }, [sortedFires, searchTerm]);
-
-  const getSelectedFireDisplayText = () => {
-    return selectedFire || "Search by fire number...";
-  };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, []);
-
-  useEffect(() => {
-    setSearchTerm('');
-  }, [selectedFire]);
-
-  const handleSelectFire = (fireNumber: string) => {
-    onFireSelect(fireNumber);
-    setSearchTerm('');
-    setIsOpen(false);
-  };
-
   return (
-    <div className="bcgov-fire-selector" ref={dropdownRef}>
-      <div className="bcgov-fire-selector-header">
-        <div className="bcgov-fire-selector-label">
-          <h4>Fire Number</h4>
-          <p>Select a fire to view burn severity</p>
-        </div>
-        <div
-          className="bcgov-fire-selector-input-container"
-          onClick={() => setIsOpen(!isOpen)}
-        >
-          <input
-            type="text"
-            placeholder={getSelectedFireDisplayText()}
-            value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsOpen(true);
-              e.currentTarget.focus();
-            }}
-            onFocus={() => setIsOpen(true)}
-            className="bcgov-fire-selector-input"
-          />
-          <button
-            className="bcgov-fire-selector-toggle"
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsOpen(!isOpen);
-              if (!isOpen) {
-                setSearchTerm('');
-              }
-            }}
-          >
-            {isOpen ? '▲' : '▼'}
-          </button>
-        </div>
-      </div>
+    <>
+      <FireYearSelector
+        selectedYear={selectedYear}
+        onYearSelect={onYearSelect}
+      />
 
-      {isOpen && (
-        <div className="bcgov-fire-selector-dropdown">
-          {fires.length === 0 ? (
-            <div className="bcgov-fire-selector-no-results">
-              No processed burn severity records available
-            </div>
-          ) : filteredFires.length > 0 ? (
-            <ul className="bcgov-fire-selector-list">
-              {filteredFires.map((fireNumber) => (
-                <li
-                  key={fireNumber}
-                  className={`bcgov-fire-selector-item ${selectedFire === fireNumber ? 'selected' : ''}`}
-                  onClick={() => handleSelectFire(fireNumber)}
-                >
-                  <div className="fire-number">{fireNumber}</div>
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <div className="bcgov-fire-selector-no-results">
-              No fires matching "{searchTerm}"
-            </div>
-          )}
-        </div>
-      )}
-    </div>
+      <FireNumberSelector
+        fires={fires}
+        selectedFire={selectedFire}
+        onFireSelect={onFireSelect}
+        disabled={!selectedYear}
+      />
+    </>
   );
 };
 
-export default FireSelector;
+export default FireSelectorDb;

--- a/frontend/src/components/ol-maps/FireYearSelector.tsx
+++ b/frontend/src/components/ol-maps/FireYearSelector.tsx
@@ -1,0 +1,51 @@
+//src/components/ol-maps/FireYearSelector.tsx
+import React from 'react';
+import './Selectors.scss';
+
+interface FireYearSelectorProps {
+  selectedYear: string | null;
+  onYearSelect: (year: string | null) => void;
+  availableYears?: string[]; // optional, defaults below
+}
+
+const getAvailableYears = (startYear: number): string[] => {
+  const currentYear = new Date().getFullYear();
+
+  return Array.from(
+    { length: currentYear - startYear + 1 },
+    (_, i) => (currentYear - i).toString()
+  );
+};
+
+const FireYearSelector: React.FC<FireYearSelectorProps> = ({
+  selectedYear,
+  onYearSelect,
+  availableYears = getAvailableYears(2025)
+}) => {
+  return (
+    <div className="bcgov-year-selector">
+      <label className="bcgov-fire-selector-label">
+        <h4>Fire Year</h4>
+        <p>Select a fire to view burn severity</p>
+      </label>
+
+      <select
+        className="bcgov-fire-selector-input"
+        value={selectedYear ?? ''}
+        onChange={(e) =>
+          onYearSelect(e.target.value || null)
+        }
+        aria-label="Select fire year"
+      >
+        <option className="bcgov-fire-selector-list" value="">Select year</option>
+        {availableYears.map(year => (
+          <option key={year} value={year}>
+            {year}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default FireYearSelector;

--- a/frontend/src/components/ol-maps/OLMap.tsx
+++ b/frontend/src/components/ol-maps/OLMap.tsx
@@ -24,6 +24,7 @@ interface OLMapProps {
   zoom?: number;
   basemap?: string;
   selectedDbFire?: string | null;
+  selectedDbYear?: string | null;
 }
 
 const OLMap: React.FC<OLMapProps> = ({
@@ -31,6 +32,7 @@ const OLMap: React.FC<OLMapProps> = ({
   zoom = 6,
   basemap = 'osm',
   selectedDbFire,
+  selectedDbYear
 }) => {
   const { isAuthenticated } = useAuth();
   
@@ -54,13 +56,13 @@ const OLMap: React.FC<OLMapProps> = ({
   }, []);
 
   // This function now uses the ref, and no longer depends on the layer state
-  const fetchAndDisplayBurnGeometry = useCallback(async (fireNumber: string) => {
+  const fetchAndDisplayBurnGeometry = useCallback(async (selectedYear: string, fireNumber: string) => {
     if (!mapInstanceRef.current) return;
     try {
       setShowLegend(true);
       setShowSummary(true);
-
-      const featureCollection = await getFireData(fireNumber);
+      console.log ("FetchAndDisplayBurnGeometry",selectedYear,fireNumber)
+      const featureCollection = await getFireData(selectedYear,fireNumber);
       
       setSelectedFireFeatureCollection(featureCollection);
 
@@ -145,7 +147,7 @@ const OLMap: React.FC<OLMapProps> = ({
     if (!mapInstanceRef.current) return;
 
     if (selectedDbFire) {
-      fetchAndDisplayBurnGeometry(selectedDbFire);
+      fetchAndDisplayBurnGeometry(selectedDbYear, selectedDbFire);
     } else {
       // If no fire is selected, clear the layer using the ref
       if (burnSeverityLayerRef.current) {

--- a/frontend/src/pages/burn-severity.tsx
+++ b/frontend/src/pages/burn-severity.tsx
@@ -1,3 +1,4 @@
+//src/pages/burn-severity.tsx
 import React, { useState, useEffect } from 'react';
 import '../style.scss';
 import './burn-severity.scss';
@@ -21,6 +22,9 @@ const BurnSeverityPage: React.FC = () => {
   const [fireNumbers, setFireNumbers] = useState<string[]>([]);
   // State for the currently selected fire number
   const [selectedDbFire, setSelectedDbFire] = useState<string | null>(null);
+  // State for the currently selected fire year
+  const currentYear = String(new Date().getFullYear());
+  const [selectedDbYear, setSelectedDbYear] = useState<string | null>(currentYear);
   // State for the currently selected documents
   const [ documents, setDocuments ] = useState<Document[]>([]);
   const [ isLoading, setIsLoading ] = useState<boolean>(false);
@@ -32,12 +36,16 @@ const BurnSeverityPage: React.FC = () => {
     setBasemap(newBasemap);
   };
   
-  // Fetch the list of fire numbers when the component mounts
+  // Fetch the list of fire numbers when a selected year changes
   useEffect(() => {
+    if (!selectedDbYear) {
+      setFireNumbers([]);
+      return;
+    }
+
     const fetchFireNumbers = async () => {
       try {
-        const data = await getFireNumbers();
-        // The API returns { "fire_numbers": [...] }, so we extract the array
+        const data = await getFireNumbers(selectedDbYear);
         if (data && Array.isArray(data.fire_numbers)) {
           setFireNumbers(data.fire_numbers);
         }
@@ -47,7 +55,8 @@ const BurnSeverityPage: React.FC = () => {
     };
 
     fetchFireNumbers();
-  }, []); // Empty dependency array ensures this runs only once on mount
+  }, [selectedDbYear]);
+
 
   useEffect(() => {
     if (!selectedDbFire) {
@@ -57,7 +66,7 @@ const BurnSeverityPage: React.FC = () => {
   const getDocuments = async () => {
     setIsLoading(true);
     try {
-      const fetchedDocs = await getFireDocuments(selectedDbFire);
+      const fetchedDocs = await getFireDocuments(selectedDbYear,selectedDbFire);
       setDocuments(fetchedDocs);
     }catch (error) {
         console.error("Failed to fetch documents:", error);
@@ -69,8 +78,15 @@ const BurnSeverityPage: React.FC = () => {
   getDocuments();
   }, [selectedDbFire]); // only should run if selected fire changes
 
+  // Handler for when a year is selected from the dropdown
+  const handleDbYearSelect = (year: string | null) => {
+    setSelectedDbYear(year);
+    setSelectedDbFire(null);   // clear fire when year changes
+    setFireNumbers([]);        // avoid stale options
+  };
+
+
   // Handler for when a fire is selected from the dropdown.
-  // This function is now much simpler.
   const handleDbFireSelect = (fireNumber: string | null) => {
     setSelectedDbFire(fireNumber);
   };
@@ -87,7 +103,9 @@ const BurnSeverityPage: React.FC = () => {
           <FireSelector_db
             fires={fireNumbers}
             onFireSelect={handleDbFireSelect}
+            onYearSelect={handleDbYearSelect}
             selectedFire={selectedDbFire}
+            selectedYear={selectedDbYear}
           />
           <h3>Documents</h3>
           <DocumentPanel
@@ -95,18 +113,6 @@ const BurnSeverityPage: React.FC = () => {
             documents= { documents }
             isLoading= { isLoading }
            />
-          {/* <AccordionGroup>
-            <Accordion label='Documents'>
-              <DocumentPanel
-                selectedDbFire={ selectedDbFire }
-                documents= { documents }
-                isLoading= { isLoading }
-              />
-            </Accordion>
-            <Accordion>
-              <BurnSeveritySummary/>
-            </Accordion>
-          </AccordionGroup> */}
         </div>
 
         {/* Center Panel - Map */}
@@ -118,6 +124,7 @@ const BurnSeverityPage: React.FC = () => {
               zoom={zoom} 
               basemap={basemap}
               selectedDbFire={selectedDbFire}
+              selectedDbYear={selectedDbYear}
             />
           </div>
           

--- a/frontend/src/pages/severity-configuration.tsx
+++ b/frontend/src/pages/severity-configuration.tsx
@@ -38,6 +38,7 @@ const ConfigurationApp: React.FC = () => {
   const [analysisFire, setAnalysisFire] = useState<string | null>(null);
   const resultsLayerRef = useRef<VectorLayer | null>(null);
   const [resultsFeatureCollection, setResultsFeatureCollection] = useState<any | null>(null);
+  const currentYear = String(new Date().getFullYear());
 
   const handleUpdateMapView = (newCenter: [number,number], newZoom: number) => {
     setCenter(newCenter)
@@ -68,7 +69,7 @@ const ConfigurationApp: React.FC = () => {
   const fetchAndDisplayBurnGeometry = useCallback(async (fireNumber: string) => {
     if (!mapInstance) return;
     try {
-      const featureCollection = await getFireData(fireNumber);
+      const featureCollection = await getFireData(currentYear,fireNumber);
       
       setResultsFeatureCollection(featureCollection);
 

--- a/frontend/src/utils/apiService.ts
+++ b/frontend/src/utils/apiService.ts
@@ -163,8 +163,9 @@ export const runBurnSeverityAnalysis = async (params: AnalysisRequest) => {
  * @returns A Promise that resolves to the feature collection data.
  */
 
-export const getFireData = async (fireNumber: string) => {
-  const response = await authedFetch(`/burn-severity/${fireNumber}`);
+export const getFireData = async (year:string, fireNumber: string) => {
+  console.log('getFireData',year,fireNumber)
+  const response = await authedFetch(`/burn-severity/${year}/${fireNumber}`);
   if (!response.ok) {
     // handle non-2xx responses here.
     const errorData = await response.json().catch(() => ({ detail: 'An unknown error occurred' }));
@@ -176,8 +177,8 @@ export const getFireData = async (fireNumber: string) => {
  * Fetch the list of documents availiable for fire number
  * response = [{"key":str,"filename":str,"url":str}]
  */
-export const getFireDocuments = async (fireNumber: string) => {
-  const response = await authedFetch(`/docs/download/${fireNumber}`);
+export const getFireDocuments = async (year:string,fireNumber: string) => {
+  const response = await authedFetch(`/docs/download/${year}/${fireNumber}`);
   if (!response.ok) {
     // handle non-2xx responses here.
     const errorData = await response.json().catch(() => ({ detail: 'An unknown error occurred' }));
@@ -198,8 +199,8 @@ export const getFireDocuments = async (fireNumber: string) => {
  * Fetches the list of all available fire numbers.
  * Protected endpoint
  */
-export const getFireNumbers = async () => {
-  const response = await authedFetch(`/burn-severity`);
+export const getFireNumbers = async (year:string) => {
+  const response = await authedFetch(`/burn-severity/${year}`);
   if (!response.ok) {
     // handle non-2xx responses here.
     const errorData = await response.json().catch(() => ({ detail: 'An unknown error occurred' }));


### PR DESCRIPTION
This pull request **introduces fire year** as a parameter to both the api and the frontend viewer. 
- Modification of api routes to allow fire year parameter
- API changes are reflected in the apiService utility
- Cleanup of unused api route /docs/list/{fire_number}
- Addition of fireYearSelector component
- Moved fire number selection to its own component fireNumberSelector
- fireSelector_db component now brings together fireYearSelector and fireNumberSelector