### PR TITLE
Add versioning to test and prod deployments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,10 +1,10 @@
-name: Deploy to prod
+name: Deploy to Prod
 
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "The image tag (PR Number) from Test to promote to Prod"
+      version:
+        description: "The verified version from Test to promote to Prod (e.g., v1.0.5)"
         type: string
         required: true
 
@@ -16,15 +16,15 @@ jobs:
   vars:
     name: Set Variables
     outputs:
-      tag: ${{ inputs.tag}}
+      version: ${{ inputs.version }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
     steps:
       - name: Echo Target Tag
-        run: echo "Deploying tag ${{ inputs.tag }} to production"
+        run: echo "Deploying version ${{ inputs.version }} to production."
 
   deploy-prod:
-    name: Deploy (prod, tag=${{ needs.vars.outputs.tag }})
+    name: Deploy (prod, version=${{ needs.vars.outputs.version }})
     needs: [vars]
     uses: ./.github/workflows/.deployer.yml
     secrets:
@@ -34,8 +34,7 @@ jobs:
       params: >-
         --set global.secrets.persist=false
         --set-string frontend.baseUrl=https://burn-severity-map-prod-frontend.apps.silver.devops.gov.bc.ca
-      tag: ${{ needs.vars.outputs.tag }}
-
+      tag: ${{ needs.vars.outputs.version }}
 
   promote:
     name: Promote Images
@@ -45,13 +44,12 @@ jobs:
       packages: write
     strategy:
       matrix:
-        # package: [migrations, backend, frontend]
-        package: [analysis,backend,frontend]
+        package: [analysis, backend, frontend]
     timeout-minutes: 1
     steps:
       - uses: shrink/actions-docker-registry-tag@v4
         with:
           registry: ghcr.io
           repository: ${{ github.repository }}/${{ matrix.package }}
-          target: ${{ needs.vars.outputs.tag }}
+          target: ${{ needs.vars.outputs.version }}
           tags: prod

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -8,6 +8,9 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
@@ -41,6 +44,7 @@ jobs:
     needs: [deploy-prod, vars]
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       packages: write
     strategy:
       matrix:

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Image tag set to deploy (e.g. PR number)"
+        description: "Manual override for image tag/version to deploy"
         type: string
         required: false
 
@@ -24,21 +24,28 @@ jobs:
   vars:
     name: Set Variables
     outputs:
-      tag: ${{ steps.tag.outputs.tag }}
+      # Use the manual input if provided, otherwise use the auto-generated version
+      tag: ${{ inputs.tag || steps.version.outputs.new_tag }}
     runs-on: ubuntu-24.04
     timeout-minutes: 1
+    # We need contents: write permission to push the new git tag
+    permissions:
+      contents: write
     steps:
-      # Get PR number for squash merges to main
-      - name: PR Number
+      - name: Checkout Code
         if: ${{ ! inputs.tag }}
-        id: pr
-        uses: bcgov-nr/action-get-pr@v0.0.1
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
 
-      - name: Set Tag
-        id: tag
-        run: echo "tag=${{ inputs.tag || steps.pr.outputs.pr }}" >> $GITHUB_OUTPUT
+      - name: Bump version and push tag
+        if: ${{ ! inputs.tag }}
+        id: version
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
 
-  # https://github.com/bcgov/quickstart-openshift-helpers
   deploy-test:
     name: Deploy (test, tag=${{ needs.vars.outputs.tag }})
     needs: [vars]
@@ -51,5 +58,3 @@ jobs:
       params: >-
         --set global.secrets.persist=false
         --set-string frontend.baseUrl=https://burn-severity-map-test-frontend.apps.silver.devops.gov.bc.ca
-
-  

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   vars:
     name: Set Variables


### PR DESCRIPTION
Split out test and prod deployments into separate workflows

- Renamed merge.yml to deploy-test.yml
- Removed deploy-prod into a new deploy-prod.yml
- Added versioning to test deployment based on https://github.com/mathieudutour/github-tag-action
- Deploy prod requires the version number to deploy