### PR TITLE
Make the list of fire years in viewer document store dependent

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -195,7 +195,7 @@ def api_health():
 
 @app.get("/health/storage")
 def storage_health():
-    if s3_connected:
+    if s3_connected():
         return {'status': 'connected'}
     else:
         return {'status': 'unreachable'}

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -86,13 +86,6 @@ def list_fire_numbers(year: str, token_payload: dict = Depends(verify_token)):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
-@app.get("/burn-severity/years", response_model=FireYearsList)
-def get_years(token_payload: dict = Depends(verify_token)):
-    try:
-        yearsList = get_years_with_features()
-        return {"fire_years": yearsList}
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
 
 @app.get("/burn-severity/{year}/{fire_number}", response_model=FeatureCollection)
 def get_fire_by_number(year: str, fire_number: str, token_payload: dict = Depends(verify_token)):
@@ -137,7 +130,13 @@ async def sync_burn_severity(year:str, fire_number: str):
         raise HTTPException(status_code=500, detail=str(e))
     return True
 
-
+@app.get("/years", response_model=FireYearsList)
+def get_years(token_payload: dict = Depends(verify_token)):
+    try:
+        yearsList = get_years_with_features()
+        return {"fire_years": yearsList}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
 # @app.get(
 #     "/docs/list/{year}/{fire_number}",
 #     summary="get list of documents related to fire_number"

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -14,8 +14,8 @@ import re
 import logging
 from oidc.oidcAuthorize import verify_token
 from utils import s3_get_presigned_url, s3_list_objects, append_geojson_to_geoparquet_s3, s3_connected, geoparquet_on_s3
-from database import get_unique_fire_numbers, get_fire_features,check_connection
-from models import FireNumberList, FeatureCollection, Feature, Geometry, FeatureProperties
+from database import get_unique_fire_numbers, get_fire_features,check_connection,get_years_with_features
+from models import FireNumberList, FeatureCollection, Feature, Geometry, FeatureProperties, FireYearsList
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -83,6 +83,14 @@ def list_fire_numbers(year: str, token_payload: dict = Depends(verify_token)):
     try:
         fire_numbers = get_unique_fire_numbers(year=year)
         return {"fire_numbers": fire_numbers}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.get("/burn-severity/years", response_model=FireYearsList)
+def get_years(token_payload: dict = Depends(verify_token)):
+    try:
+        yearsList = get_years_with_features()
+        return {"fire_years": yearsList}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 

--- a/backend/api/models.py
+++ b/backend/api/models.py
@@ -31,3 +31,5 @@ class FeatureCollection(BaseModel):
 
 class FireNumberList(BaseModel):
     fire_numbers: List[str]
+class FireYearsList(BaseModel):
+    fire_years: List[int]

--- a/frontend/index.d.ts
+++ b/frontend/index.d.ts
@@ -1,3 +1,4 @@
+declare module '*.scss';
 declare module "*.png" {
    const value: any;
    export = value;

--- a/frontend/src/components/ol-maps/FireSelector_db.tsx
+++ b/frontend/src/components/ol-maps/FireSelector_db.tsx
@@ -4,6 +4,7 @@ import FireNumberSelector from './FireNumberSelector';
 
 interface FireSelectorDbProps {
   fires: string[];
+  availableYears: string[];
   selectedYear: string | null;
   selectedFire: string | null;
   onYearSelect: (year: string | null) => void;
@@ -12,6 +13,7 @@ interface FireSelectorDbProps {
 
 const FireSelectorDb: React.FC<FireSelectorDbProps> = ({
   fires,
+  availableYears,
   selectedYear,
   selectedFire,
   onYearSelect,
@@ -20,6 +22,7 @@ const FireSelectorDb: React.FC<FireSelectorDbProps> = ({
   return (
     <>
       <FireYearSelector
+        availableYears={availableYears}
         selectedYear={selectedYear}
         onYearSelect={onYearSelect}
       />

--- a/frontend/src/components/ol-maps/FireYearSelector.tsx
+++ b/frontend/src/components/ol-maps/FireYearSelector.tsx
@@ -1,27 +1,32 @@
 //src/components/ol-maps/FireYearSelector.tsx
 import React from 'react';
 import './Selectors.scss';
+import { getFireYears } from '../../utils/apiService';
+
 
 interface FireYearSelectorProps {
   selectedYear: string | null;
   onYearSelect: (year: string | null) => void;
-  availableYears?: string[]; // optional, defaults below
+  availableYears?: string[]; 
 }
-
-const getAvailableYears = (startYear: number): string[] => {
-  const currentYear = new Date().getFullYear();
-
-  return Array.from(
-    { length: currentYear - startYear + 1 },
-    (_, i) => (currentYear - i).toString()
-  );
-};
 
 const FireYearSelector: React.FC<FireYearSelectorProps> = ({
   selectedYear,
   onYearSelect,
-  availableYears = getAvailableYears(2025)
+  availableYears
 }) => {
+  const [years, setYears] = React.useState<string[]>(availableYears ?? []);
+
+  React.useEffect(() => {
+    if (!availableYears || availableYears.length === 0) {
+      getFireYears()
+        .then(setYears)
+        .catch(console.error);
+    } else {
+      setYears(availableYears);
+    }
+  }, [availableYears]);
+
   return (
     <div className="bcgov-year-selector">
       <label className="bcgov-fire-selector-label">
@@ -38,7 +43,7 @@ const FireYearSelector: React.FC<FireYearSelectorProps> = ({
         aria-label="Select fire year"
       >
         <option className="bcgov-fire-selector-list" value="">Select year</option>
-        {availableYears.map(year => (
+        {years.map(year => (
           <option key={year} value={year}>
             {year}
           </option>

--- a/frontend/src/components/ol-maps/FireYearSelector.tsx
+++ b/frontend/src/components/ol-maps/FireYearSelector.tsx
@@ -1,13 +1,12 @@
 //src/components/ol-maps/FireYearSelector.tsx
 import React from 'react';
 import './Selectors.scss';
-import { getFireYears } from '../../utils/apiService';
 
 
 interface FireYearSelectorProps {
   selectedYear: string | null;
   onYearSelect: (year: string | null) => void;
-  availableYears?: string[]; 
+  availableYears: string[]; 
 }
 
 const FireYearSelector: React.FC<FireYearSelectorProps> = ({
@@ -15,17 +14,6 @@ const FireYearSelector: React.FC<FireYearSelectorProps> = ({
   onYearSelect,
   availableYears
 }) => {
-  const [years, setYears] = React.useState<string[]>(availableYears ?? []);
-
-  React.useEffect(() => {
-    if (!availableYears || availableYears.length === 0) {
-      getFireYears()
-        .then(setYears)
-        .catch(console.error);
-    } else {
-      setYears(availableYears);
-    }
-  }, [availableYears]);
 
   return (
     <div className="bcgov-year-selector">
@@ -43,7 +31,7 @@ const FireYearSelector: React.FC<FireYearSelectorProps> = ({
         aria-label="Select fire year"
       >
         <option className="bcgov-fire-selector-list" value="">Select year</option>
-        {years.map(year => (
+        {availableYears.map(year => (
           <option key={year} value={year}>
             {year}
           </option>

--- a/frontend/src/pages/burn-severity.tsx
+++ b/frontend/src/pages/burn-severity.tsx
@@ -38,6 +38,7 @@ const BurnSeverityPage: React.FC = () => {
   };
   //get fire years on load
   useEffect(() => {
+    if (!isAuthenticated) return;
     console.log("Attempting to fetch years...");
     getFireYears()
       .then((years) => {
@@ -47,7 +48,7 @@ const BurnSeverityPage: React.FC = () => {
       .catch((err) => {
         console.error("Critical error fetching years:", err);
       });
-  }, []);
+  }, [isAuthenticated]);
 
 
   // Fetch the list of fire numbers when a selected year changes

--- a/frontend/src/pages/burn-severity.tsx
+++ b/frontend/src/pages/burn-severity.tsx
@@ -7,7 +7,7 @@ import BasemapSelector from '../components/ol-maps/BasemapSelector';
 import FireSelector_db from '../components/ol-maps/FireSelector_db';
 import DocumentPanel from '../components/DocumentPanel'
 import { useAuth } from '../auth/AuthContext';
-import { getFireData, getFireNumbers, getFireDocuments, Document } from "../utils/apiService";
+import { getFireData, getFireYears, getFireNumbers, getFireDocuments, Document } from "../utils/apiService";
 import { Accordion, AccordionGroup } from '@bcgov/design-system-react-components';
 import BurnSeveritySummary from '../components/ol-maps/BurnSeveritySummary';
 

--- a/frontend/src/pages/burn-severity.tsx
+++ b/frontend/src/pages/burn-severity.tsx
@@ -24,6 +24,7 @@ const BurnSeverityPage: React.FC = () => {
   const [selectedDbFire, setSelectedDbFire] = useState<string | null>(null);
   // State for the currently selected fire year
   const currentYear = String(new Date().getFullYear());
+  const [availableYears, setAvailableYears] = useState<string[]>([]);
   const [selectedDbYear, setSelectedDbYear] = useState<string | null>(currentYear);
   // State for the currently selected documents
   const [ documents, setDocuments ] = useState<Document[]>([]);
@@ -78,6 +79,11 @@ const BurnSeverityPage: React.FC = () => {
   getDocuments();
   }, [selectedDbFire]); // only should run if selected fire changes
 
+  useEffect(() => {
+    getFireYears()
+      .then(setAvailableYears)
+      .catch(console.error);
+  }, []);
   // Handler for when a year is selected from the dropdown
   const handleDbYearSelect = (year: string | null) => {
     setSelectedDbYear(year);
@@ -102,6 +108,7 @@ const BurnSeverityPage: React.FC = () => {
           <h3>Processed Burn Severity Fires</h3>
           <FireSelector_db
             fires={fireNumbers}
+            availableYears={availableYears}
             onFireSelect={handleDbFireSelect}
             onYearSelect={handleDbYearSelect}
             selectedFire={selectedDbFire}

--- a/frontend/src/pages/burn-severity.tsx
+++ b/frontend/src/pages/burn-severity.tsx
@@ -25,7 +25,7 @@ const BurnSeverityPage: React.FC = () => {
   // State for the currently selected fire year
   const currentYear = String(new Date().getFullYear());
   const [availableYears, setAvailableYears] = useState<string[]>([]);
-  const [selectedDbYear, setSelectedDbYear] = useState<string | null>(currentYear);
+  const [selectedDbYear, setSelectedDbYear] = useState<string | null>(null);
   // State for the currently selected documents
   const [ documents, setDocuments ] = useState<Document[]>([]);
   const [ isLoading, setIsLoading ] = useState<boolean>(false);
@@ -36,7 +36,20 @@ const BurnSeverityPage: React.FC = () => {
   const handleBasemapChange = (newBasemap: string) => {
     setBasemap(newBasemap);
   };
-  
+  //get fire years on load
+  useEffect(() => {
+    console.log("Attempting to fetch years...");
+    getFireYears()
+      .then((years) => {
+        console.log("Years fetched successfully:", years);
+        setAvailableYears(years);
+      })
+      .catch((err) => {
+        console.error("Critical error fetching years:", err);
+      });
+  }, []);
+
+
   // Fetch the list of fire numbers when a selected year changes
   useEffect(() => {
     if (!selectedDbYear) {
@@ -79,11 +92,6 @@ const BurnSeverityPage: React.FC = () => {
   getDocuments();
   }, [selectedDbFire]); // only should run if selected fire changes
 
-  useEffect(() => {
-    getFireYears()
-      .then(setAvailableYears)
-      .catch(console.error);
-  }, []);
   // Handler for when a year is selected from the dropdown
   const handleDbYearSelect = (year: string | null) => {
     setSelectedDbYear(year);

--- a/frontend/src/utils/apiService.ts
+++ b/frontend/src/utils/apiService.ts
@@ -18,7 +18,7 @@ let activeHealthCheck: Promise<HealthResponse> | null = null;
 
 const ensureDataReady = async (): Promise<void> => {
   if (cachedDataStatus === 'ok') return;
-
+  console.log("Checking system health...");
   if (cachedDataStatus === null || cachedDataStatus === 'not created') {
     await fetchHealth();
   }

--- a/frontend/src/utils/apiService.ts
+++ b/frontend/src/utils/apiService.ts
@@ -238,7 +238,7 @@ export const getFireNumbers = async (year:string) => {
  * Fetch the list years for with bs results
  */
 export const getFireYears = async () => {
-  await ensureDataReady();
+  //await ensureDataReady();
 
   const response = await authedFetch(`/years`);
   if (!response.ok) {
@@ -247,7 +247,7 @@ export const getFireYears = async () => {
     throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
   }
   const data = await response.json();
-  
+  console.log('getFireYears response:',data);
   // Extract the array, convert numbers to strings
   if (data && Array.isArray(data.fire_years)) {
     return data.fire_years.map((y: number | string) => String(y));

--- a/frontend/src/utils/apiService.ts
+++ b/frontend/src/utils/apiService.ts
@@ -234,6 +234,26 @@ export const getFireNumbers = async (year:string) => {
   return response.json();
 };
 
+/**
+ * Fetch the list years for with bs results
+ */
+export const getFireYears = async () => {
+  await ensureDataReady();
+
+  const response = await authedFetch(`/years`);
+  if (!response.ok) {
+    // handle non-2xx responses here.
+    const errorData = await response.json().catch(() => ({ detail: 'An unknown error occurred' }));
+    throw new Error(errorData.detail || `HTTP error! status: ${response.status}`);
+  }
+  const data = await response.json();
+  
+  // Extract the array, convert numbers to strings
+  if (data && Array.isArray(data.fire_years)) {
+    return data.fire_years.map((y: number | string) => String(y));
+  }
+};
+
 export const syncFireResults = async (year: string,fire_number: string) => {
   await ensureDataReady();
   const response = await authedFetch(`/sync-burn-severity/${year}/${fire_number}`);


### PR DESCRIPTION
This pull request is to make the list of fire years in viewer document store dependent. Only fire years with burn severity results will be contained in the fire year drop down in the viewer.

**Summary of changes:**
- fire years is now stored in state within the burn severity viewer
- apiservice now has a fetch for fire years
- api now has a /years route to return fire years that have bs results
- cleaned up remaining static year properties